### PR TITLE
Allow comment lines to start with any number of slashes.

### DIFF
--- a/src/com/stuffwithstuff/magpie/parser/Lexer.java
+++ b/src/com/stuffwithstuff/magpie/parser/Lexer.java
@@ -131,16 +131,24 @@ public class Lexer implements TokenReader {
   
   private Token readLineComment() {
     advance(); // Consume second "/".
+
+    int slashCount = 2;
+
+    // Consume any number of additional leading "/".
+    while (peek() == '/') {
+      ++slashCount;
+      advance();
+    }
     
     // See if it's a "///" doc comment.
-    boolean isDoc = (peek() == '/');
+    boolean isDoc = slashCount == 3;
       
     while (true) {
       switch (peek()) {
       case '\n':
       case '\r':
       case '\0':
-        String value = mRead.substring(isDoc ? 3 : 2).trim();
+        String value = mRead.substring(slashCount).trim();
         return makeToken(
             isDoc ? TokenType.DOC_COMMENT : TokenType.LINE_COMMENT, value);
         


### PR DESCRIPTION
Hit a syntax error when I'd put a temporary separator line (like 80
slashes) in a file. This changes the lexer to eat and discard any
number of leading slashes. Doc comments still only start with "///".
