### PR TITLE
Platform fixes

### DIFF
--- a/src/Platform/Environment.h
+++ b/src/Platform/Environment.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 namespace magpie
 {
   // Fills in [path] with the full path to the root directory containing the

--- a/src/Platform/Environment_linux.cpp
+++ b/src/Platform/Environment_linux.cpp
@@ -1,5 +1,5 @@
 #include <unistd.h>
-#include <linux/limits.h>
+#include <cstring>
 
 #include "Macros.h"
 #include "Environment.h"
@@ -8,9 +8,9 @@ namespace magpie
 {
   void getCoreLibPath(char* path, uint32_t length)
   {
-    char relativePath[PATH_MAX];
+    char* relativePath = new char[length];
 
-    int len = readlink("/proc/self/exe", relativePath, PATH_MAX-1);
+    int len = readlink("/proc/self/exe", relativePath, length-1);
     ASSERT(len != -1, "Executable path too long.");
     relativePath[len] = '\0';
 
@@ -33,13 +33,14 @@ namespace magpie
     // TODO(bob): Hack. Try to work from the build directory too.
     if (strstr(relativePath, "1/out") != 0)
     {
-      strncat(relativePath, "/../../..", PATH_MAX);
+      strncat(relativePath, "/../../..", length);
     }
 
     // Add library path.
-    strncat(relativePath, "/core/core.mag", PATH_MAX);
+    strncat(relativePath, "/core/core.mag", length);
 
     // Canonicalize the path.
     realpath(relativePath, path);
+    delete[] relativePath;
   }
 }

--- a/src/Platform/Environment_mac.cpp
+++ b/src/Platform/Environment_mac.cpp
@@ -1,4 +1,5 @@
 #include <mach-o/dyld.h>
+#include <cstring>
 
 #include "Macros.h"
 #include "Environment.h"
@@ -7,9 +8,9 @@ namespace magpie
 {
   void getCoreLibPath(char* path, uint32_t length)
   {
-    char relativePath[PATH_MAX];
-    
-    uint32_t size = PATH_MAX;
+    char* relativePath = new char[length];
+
+    uint32_t size = length;
     int result = _NSGetExecutablePath(relativePath, &size);
     ASSERT(result == 0, "Executable path too long.");
 
@@ -33,13 +34,14 @@ namespace magpie
     if (strstr(relativePath, "build/Debug") != 0 ||
         strstr(relativePath, "build/Release") != 0)
     {
-      strncat(relativePath, "/../..", PATH_MAX);
+      strncat(relativePath, "/../..", length);
     }
 
     // Add library path.
-    strncat(relativePath, "/core/core.mag", PATH_MAX);
+    strncat(relativePath, "/core/core.mag", length);
 
     // Canonicalize the path.
     realpath(relativePath, path);
+    delete[] relativePath;
   }
 }

--- a/src/Platform/Environment_win.cpp
+++ b/src/Platform/Environment_win.cpp
@@ -1,4 +1,6 @@
-#include <mach-o/dyld.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <cstring>
 
 #include "Macros.h"
 #include "Environment.h"
@@ -7,10 +9,9 @@ namespace magpie
 {
   void getCoreLibPath(char* path, uint32_t length)
   {
-    char relativePath[PATH_MAX];
+    char* relativePath = new char[length];
 
-    // TODO(bob): Move platform-specific stuff out to another file.
-    GetModuleFileName(NULL, relativePath, PATH_MAX);
+    GetModuleFileName(NULL, relativePath, length);
     ASSERT(GetLastError() != ERROR_INSUFFICIENT_BUFFER, "Executable path too long.")
 
     // Cut off file name from path
@@ -33,7 +34,7 @@ namespace magpie
     if (strstr(relativePath, "Debug") != 0 ||
         strstr(relativePath, "Release") != 0)
     {
-      strncat(relativePath, "/..", PATH_MAX);
+      strncat(relativePath, "/..", length);
     }
 
     // Add library path.
@@ -41,5 +42,6 @@ namespace magpie
 
     // Canonicalize the path.
     _fullpath(path, relativePath, length);
+    delete[] relativePath;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <cstring>
-#include <stdint.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -10,6 +8,11 @@
 #define PATH_MAX MAX_PATH
 #define EX_NOINPUT 1
 #else
+#ifdef __linux__
+#include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
 #include <sysexits.h>
 #endif
 


### PR DESCRIPTION
Corrected platform files (added some includes, use the `length` parameter in `getCoreLibPath` functions).

With these changes everything works on Windows + Linux.
Please test on OSX, as always :)
