### PR TITLE
[JVM] Don't throw on end of STDIN.

### DIFF
--- a/src/com/stuffwithstuff/magpie/parser/StringReader.java
+++ b/src/com/stuffwithstuff/magpie/parser/StringReader.java
@@ -10,7 +10,9 @@ import com.stuffwithstuff.magpie.util.Expect;
 public class StringReader implements SourceReader {
   public StringReader(String description, String text) {
     Expect.notNull(description);
-    Expect.notNull(text);
+    if (text == null) {
+      System.exit(0);
+    }
 
     mDescription = description;
     mText = text;


### PR DESCRIPTION
This enables both of these, without throwing an exception:
- ctrl-d at the REPL prompt to quit
- `echo 2+2 | ./magpie`
